### PR TITLE
Change E to R in word puzzle

### DIFF
--- a/src/epub/text/chapter-7.xhtml
+++ b/src/epub/text/chapter-7.xhtml
@@ -307,7 +307,7 @@
 			<p>Sholmes experienced that slight fluttering of the heart which always announced to him, in the clearest manner, that he had discovered the road which leads to victory. That ray of truth, that feeling of certainty, never deceived him.</p>
 			<p>With nervous fingers he hastened to examine the balance of the book. Very soon he made another discovery. It was a page composed of capital letters, followed by a line of figures. Nine of those letters and three of those figures had been carefully cut out. Sholmes made a list of the missing letters and figures in his memorandum book, in alphabetical and numerical order, and obtained the following result:</p>
 			<blockquote>
-				<p>CDEHNOPEZ⁠—237.</p>
+				<p>CDEHNOPRZ⁠—237.</p>
 			</blockquote>
 			<p>“Well! at first sight, it is a rather formidable puzzle,” he murmured, “but, by transposing the letters and using all of them, is it possible to form one, two or three complete words?”</p>
 			<p>Sholmes tried it, in vain.</p>


### PR DESCRIPTION
Possible mis-scan from original?

The letters in the puzzle didn't match the narrative in the text and were a different set of letters from the 'decyphered' version a few lines later.
I checked against [this page](https://fr.wikisource.org/wiki/Page%3ALeblanc_-_Ars%C3%A8ne_Lupin_contre_Herlock_Sholmes%2C_1914.djvu/82) of the French original.