### PR TITLE
Typo: Holmes -> Sholmes

### DIFF
--- a/src/epub/text/chapter-6.xhtml
+++ b/src/epub/text/chapter-6.xhtml
@@ -273,7 +273,7 @@
 			<p>He spoke with simplicity and candor. Sholmes replied by an almost imperceptible inclination of his head, and murmured:</p>
 			<p>“Very well, the blue diamond.”</p>
 			<p>“Take my cane, there, at the end of the mantel. Press on the head of the cane with one hand, and, with the other, turn the iron ferrule at the bottom.”</p>
-			<p>Holmes took the cane and followed the directions. As he did so, the head of the cane divided and disclosed a cavity which contained a small ball of wax which, in turn, enclosed a diamond. He examined it. It was the blue diamond.</p>
+			<p>Sholmes took the cane and followed the directions. As he did so, the head of the cane divided and disclosed a cavity which contained a small ball of wax which, in turn, enclosed a diamond. He examined it. It was the blue diamond.</p>
 			<p>“Monsieur Lupin, Mademoiselle Destange is free.”</p>
 			<p>“Is her future safety assured? Has she nothing to fear from you?”</p>
 			<p>“Neither from me, nor anyone else.”</p>


### PR DESCRIPTION
As follow-up from [another issue](https://github.com/standardebooks/maurice-leblanc_the-hollow-needle_alexander-teixeira-de-mattos/issues/2), this fixes one instance where Sholmes was referred to as "Holmes".

Note that there is one reference to "Sherlock Holmes" as a fictional character that was left unchanged:
> He is devoid of those flashes of genius which characterize the work of Dupin, Lecoq and Sherlock Holmes.

This is another case of Leblanc playing with the distinction between "fictional detective Sherlock Holmes" and "Lupin's rival Herlock Sholmes".